### PR TITLE
fix filtering bug

### DIFF
--- a/src/util/cognito-util.ts
+++ b/src/util/cognito-util.ts
@@ -58,7 +58,7 @@ export const forceCreateUser = (cognitoIsp: CognitoIdentityServiceProvider, data
 };
 
 export const createParam = (userPoolId: string, data: any) => {
-  const attributes = data.Attributes.filter((a: any) => a.Name !== 'sub' || a.Name !== 'identities');
+  const attributes = data.Attributes.filter((a: any) => a.Name !== 'sub' && a.Name !== 'identities');
   const email = data.Attributes.filter((a: any) => a.Name === 'email')[0].Value;
   // Username = email
   return {

--- a/test/util/cognito_util.test.ts
+++ b/test/util/cognito_util.test.ts
@@ -29,5 +29,9 @@ describe('Restore test', () => {
   it('eq createParam', () => {
     assert.deepEqual(param.UserPoolId, userPoolId);
     assert.deepEqual(param.Username, data.Attributes[4].Value);
+    assert.notDeepInclude(param.UserAttributes, {
+      'Name': 'sub',
+      'Value': '0416cdc1-b426-4d66-8f0b-c26896f39c4a',
+    });
   });
 });

--- a/test/util/cognito_util.test.ts
+++ b/test/util/cognito_util.test.ts
@@ -29,7 +29,7 @@ describe('Restore test', () => {
   it('eq createParam', () => {
     assert.deepEqual(param.UserPoolId, userPoolId);
     assert.deepEqual(param.Username, data.Attributes[4].Value);
-    assert.notDeepInclude(param.UserAttributes, {
+    assert.notDeepInclude(param.UserAttributes, { // this attribute will be filtered
       'Name': 'sub',
       'Value': '0416cdc1-b426-4d66-8f0b-c26896f39c4a',
     });


### PR DESCRIPTION
`a.Name !== 'sub' || a.Name !== 'identities'` is always true.
So, I  corrected this statement, `a.Name !== 'sub' && a.Name !== 'identities'`.